### PR TITLE
use branch 3.0release of srs

### DIFF
--- a/build/auto_build_srs.sh
+++ b/build/auto_build_srs.sh
@@ -9,7 +9,7 @@ echo "download srs..."
 cd $home
 SRS_DIR=./srs
 if [ ! -d "$SRS_DIR" ]; then
-    git clone https://github.com/ossrs/srs.git
+    git clone -b 3.0release https://github.com/ossrs/srs.git
 fi
 cd $home
 echo "download srs success"


### PR DESCRIPTION
the latest version of SRS does't have ./src/libs/srs_librtmp.hpp any more, so use branch 3.0release is nessary.